### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ What I usually do is I start a session with an empty file and ask AI to start th
 ## Installation
 Installation instruction provided by Claude with MCP knowledge and modified by me after testing. I would appreciate any assistance in organizing this section.
 
+### Installing via Smithery
+
+To install MemoryMesh for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/memorymesh):
+
+```bash
+npx @smithery/cli install memorymesh --client claude
+```
+
 ### Prerequisites
 Node.js 18 or higher
 npm (included with Node.js)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MemoryMesh
+[![smithery badge](https://smithery.ai/badge/memorymesh)](https://smithery.ai/protocol/memorymesh)
 
 This project is based on the [Knowledge Graph Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) from the MCP servers repository and retains its core functionality. For installation details beyond what’s provided here, refer to the original repository link above if needed. The main entry point of this application is the index.js file.
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install MemoryMesh for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. I also added a little badge for the number of installs!