### PR TITLE
refactor-callToolHandler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorymesh",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorymesh",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorymesh",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An MCP server that uses a knowledge graph to store and recall structured memory for AI models",
   "license": "MIT",
   "author": "CheMiguel23",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -31,7 +31,7 @@ interface Config {
 export const CONFIG: Config = {
     SERVER: {
         NAME: 'memorymesh',
-        VERSION: '0.2.2',
+        VERSION: '0.2.3',
     },
 
     PATHS: {

--- a/src/core/GraphManager.ts
+++ b/src/core/GraphManager.ts
@@ -1,0 +1,64 @@
+// src/core/GraphManager.ts
+
+import {KnowledgeGraphManagerBase} from './KnowledgeGraphManagerBase.js';
+import {GraphOperations} from './operations/index.js';
+import type {Node, Edge} from '../types/graph.js';
+import type {
+    MetadataAddition,
+    MetadataDeletion,
+    EdgeFilter,
+    MetadataResult,
+    GetEdgesResult, IStorage
+} from '../types/index.js';
+
+/**
+ * Handles graph-specific operations (nodes, edges, metadata)
+ */
+export class GraphManager extends KnowledgeGraphManagerBase {
+    private readonly graphOperations: GraphOperations;
+
+    constructor(storage?: IStorage) {
+        super(storage);
+        const {nodeManager, edgeManager, metadataManager} = this.createManagers();
+        this.graphOperations = new GraphOperations(nodeManager, edgeManager, metadataManager);
+    }
+
+    // Node operations
+    async addNodes(nodes: Node[]): Promise<Node[]> {
+        return this.graphOperations.addNodes(nodes);
+    }
+
+    async updateNodes(nodes: Partial<Node>[]): Promise<Node[]> {
+        return this.graphOperations.updateNodes(nodes);
+    }
+
+    async deleteNodes(nodeNames: string[]): Promise<void> {
+        return this.graphOperations.deleteNodes(nodeNames);
+    }
+
+    // Edge operations
+    async addEdges(edges: Edge[]): Promise<Edge[]> {
+        return this.graphOperations.addEdges(edges);
+    }
+
+    async updateEdges(edges: Edge[]): Promise<Edge[]> {
+        return this.graphOperations.updateEdges(edges);
+    }
+
+    async deleteEdges(edges: Edge[]): Promise<void> {
+        return this.graphOperations.deleteEdges(edges);
+    }
+
+    async getEdges(filter?: EdgeFilter): Promise<GetEdgesResult> {
+        return this.graphOperations.getEdges(filter);
+    }
+
+    // Metadata operations
+    async addMetadata(metadata: MetadataAddition[]): Promise<MetadataResult[]> {
+        return this.graphOperations.addMetadata(metadata);
+    }
+
+    async deleteMetadata(deletions: MetadataDeletion[]): Promise<void> {
+        return this.graphOperations.deleteMetadata(deletions);
+    }
+}

--- a/src/core/KnowledgeGraphManagerBase.ts
+++ b/src/core/KnowledgeGraphManagerBase.ts
@@ -1,0 +1,27 @@
+// src/core/KnowledgeGraphManagerBase.ts
+
+import type {Graph} from '../types/graph.js';
+import type {IStorage} from '../types/storage.js';
+import {JsonLineStorage} from './storage/JsonLineStorage.js';
+import {ManagerFactory} from './managers/ManagerFactory.js';
+
+/**
+ * Base class that handles initialization and common functionality
+ */
+export abstract class KnowledgeGraphManagerBase {
+    protected readonly storage: IStorage;
+
+    constructor(storage: IStorage = new JsonLineStorage()) {
+        this.storage = storage;
+    }
+
+    protected createManagers() {
+        return {
+            nodeManager: ManagerFactory.createNodeManager(this.storage),
+            edgeManager: ManagerFactory.createEdgeManager(this.storage),
+            metadataManager: ManagerFactory.createMetadataManager(this.storage),
+            searchManager: ManagerFactory.createSearchManager(this.storage),
+            transactionManager: ManagerFactory.createTransactionManager(this.storage)
+        };
+    }
+}

--- a/src/core/SearchManager.ts
+++ b/src/core/SearchManager.ts
@@ -1,0 +1,31 @@
+// src/core/SearchManager.ts
+
+import {KnowledgeGraphManagerBase} from './KnowledgeGraphManagerBase.js';
+import {SearchOperations} from './operations/index.js';
+import type {Graph} from '../types/graph.js';
+import type {IStorage, OpenNodesResult} from '../types/index.js';
+
+/**
+ * Handles search-related operations
+ */
+export class SearchManager extends KnowledgeGraphManagerBase {
+    private readonly searchOperations: SearchOperations;
+
+    constructor(storage?: IStorage) {
+        super(storage);
+        const {searchManager} = this.createManagers();
+        this.searchOperations = new SearchOperations(searchManager);
+    }
+
+    async readGraph(): Promise<Graph> {
+        return this.searchOperations.readGraph();
+    }
+
+    async searchNodes(query: string): Promise<OpenNodesResult> {
+        return this.searchOperations.searchNodes(query);
+    }
+
+    async openNodes(names: string[]): Promise<OpenNodesResult> {
+        return this.searchOperations.openNodes(names);
+    }
+}

--- a/src/core/TransactionManager.ts
+++ b/src/core/TransactionManager.ts
@@ -1,0 +1,47 @@
+// src/core/TransactionManager.ts
+
+import {KnowledgeGraphManagerBase} from './KnowledgeGraphManagerBase.js';
+import {TransactionOperations} from './operations/index.js';
+import type {Graph} from '../types/graph.js';
+import {IStorage} from "../types/index.js";
+
+/**
+ * Handles transaction-related operations
+ */
+export class TransactionManager extends KnowledgeGraphManagerBase {
+    private readonly transactionOperations: TransactionOperations;
+
+    constructor(storage?: IStorage) {
+        super(storage);
+        const {transactionManager} = this.createManagers();
+        this.transactionOperations = new TransactionOperations(transactionManager);
+    }
+
+    async beginTransaction(): Promise<void> {
+        return this.transactionOperations.beginTransaction();
+    }
+
+    async commit(): Promise<void> {
+        return this.transactionOperations.commit();
+    }
+
+    async rollback(): Promise<void> {
+        return this.transactionOperations.rollback();
+    }
+
+    async withTransaction<T>(operation: () => Promise<T>): Promise<T> {
+        return this.transactionOperations.withTransaction(operation);
+    }
+
+    async addRollbackAction(action: () => Promise<void>, description: string): Promise<void> {
+        return this.transactionOperations.addRollbackAction(action, description);
+    }
+
+    isInTransaction(): boolean {
+        return this.transactionOperations.isInTransaction();
+    }
+
+    getCurrentGraph(): Graph {
+        return this.transactionOperations.getCurrentGraph();
+    }
+}

--- a/src/tools/callToolHandler.ts
+++ b/src/tools/callToolHandler.ts
@@ -1,7 +1,7 @@
 // src/tools/callToolHandler.ts
 
-import {dynamicTools} from './tools.js';
-import {formatToolResponse, formatToolError} from '../utils/responseFormatter.js';
+import {ToolHandlerFactory} from './handlers/ToolHandlerFactory.js';
+import {formatToolError} from '../utils/responseFormatter.js';
 import type {KnowledgeGraphManager} from '../types/managers.js';
 import type {ToolResponse} from '../types/tools.js';
 
@@ -19,124 +19,30 @@ export async function handleCallToolRequest(
     request: ToolCallRequest,
     knowledgeGraphManager: KnowledgeGraphManager
 ): Promise<ToolResponse> {
-    const {name, arguments: args} = request.params;
-
-    if (!args) {
-        return formatToolError({
-            operation: name,
-            error: "No arguments provided",
-            suggestions: ["Provide arguments for the tool call"]
-        });
-    }
-
     try {
-        // First check if it's a generic tool
-        switch (name) {
-            case "add_nodes":
-                return formatToolResponse({
-                    data: {nodes: await knowledgeGraphManager.addNodes(args.nodes)},
-                    message: `Successfully added ${args.nodes.length} nodes`,
-                    actionTaken: "Added nodes to the knowledge graph"
-                });
+        const {name, arguments: args} = request.params;
 
-            case "update_nodes":
-                return formatToolResponse({
-                    data: {nodes: await knowledgeGraphManager.updateNodes(args.nodes)},
-                    message: `Successfully updated ${args.nodes.length} nodes`,
-                    actionTaken: "Updated nodes in the knowledge graph"
-                });
-
-            case "add_edges":
-                return formatToolResponse({
-                    data: {edges: await knowledgeGraphManager.addEdges(args.edges)},
-                    message: `Successfully added ${args.edges.length} edges`,
-                    actionTaken: "Added edges to the knowledge graph"
-                });
-
-            case "update_edges":
-                return formatToolResponse({
-                    data: {edges: await knowledgeGraphManager.updateEdges(args.edges)},
-                    message: `Successfully updated ${args.edges.length} edges`,
-                    actionTaken: "Updated edges in the knowledge graph"
-                });
-
-            case "add_metadata":
-                return formatToolResponse({
-                    data: {metadata: await knowledgeGraphManager.addMetadata(args.metadata)},
-                    message: `Successfully added metadata`,
-                    actionTaken: "Added metadata to nodes in the knowledge graph"
-                });
-
-            case "delete_nodes":
-                await knowledgeGraphManager.deleteNodes(args.nodeNames);
-                return formatToolResponse({
-                    message: `Successfully deleted nodes: ${args.nodeNames.join(', ')}`,
-                    actionTaken: "Deleted nodes from the knowledge graph"
-                });
-
-            case "delete_metadata":
-                await knowledgeGraphManager.deleteMetadata(args.deletions);
-                return formatToolResponse({
-                    message: `Successfully deleted metadata`,
-                    actionTaken: "Deleted metadata from nodes in the knowledge graph"
-                });
-
-            case "delete_edges":
-                await knowledgeGraphManager.deleteEdges(args.edges);
-                return formatToolResponse({
-                    message: `Successfully deleted edges`,
-                    actionTaken: "Deleted edges from the knowledge graph"
-                });
-
-            case "read_graph":
-                return formatToolResponse({
-                    data: await knowledgeGraphManager.readGraph(),
-                    message: `Successfully read the knowledge graph`,
-                    actionTaken: "Read the knowledge graph"
-                });
-
-            case "search_nodes":
-                return formatToolResponse({
-                    data: await knowledgeGraphManager.searchNodes(args.query),
-                    message: `Successfully searched nodes with query: ${args.query}`,
-                    actionTaken: "Searched nodes in the knowledge graph"
-                });
-
-            case "open_nodes":
-                return formatToolResponse({
-                    data: await knowledgeGraphManager.openNodes(args.names),
-                    message: `Successfully opened nodes: ${args.names.join(', ')}`,
-                    actionTaken: "Opened nodes in the knowledge graph"
-                });
-
-            default:
-                // Only try schema-based handling if it's not a generic tool
-                if (name.match(/^(add|update|delete)_/)) {
-                    const toolResult = await dynamicTools.handleToolCall(name, args, knowledgeGraphManager);
-                    // Check if the toolResult is already formatted
-                    if (toolResult?.toolResult?.isError) {
-                        return toolResult;
-                    }
-                    return formatToolResponse({
-                        data: toolResult,
-                        message: `Successfully executed tool: ${name}`,
-                        actionTaken: `Executed tool: ${name}`
-                    });
-                }
-
-                return formatToolError({
-                    operation: name,
-                    error: `Unknown tool: ${name}`,
-                    suggestions: ["Check the list of available tools"]
-                });
+        if (!args) {
+            throw new Error("Tool arguments are required");
         }
+
+        // Initialize handlers if needed
+        if (!ToolHandlerFactory.getHandler(name)) {
+            ToolHandlerFactory.initialize(knowledgeGraphManager);
+        }
+
+        // Get appropriate handler and process the request
+        const handler = ToolHandlerFactory.getHandler(name);
+        return await handler.handleTool(name, args);
+
     } catch (error) {
+        console.error("Error in handleCallToolRequest:", error);
         return formatToolError({
-            operation: name,
+            operation: "callTool",
             error: error instanceof Error ? error.message : 'Unknown error occurred',
-            context: {input: args},
-            suggestions: ["Review the error message and the provided arguments"],
-            recoverySteps: ["If the error persists, notify the human"]
+            context: {request},
+            suggestions: ["Examine the tool input parameters for correctness.", "Verify that the requested operation is supported."],
+            recoverySteps: ["Adjust the input parameters based on the schema definition."]
         });
     }
 }

--- a/src/tools/handlers/BaseToolHandler.ts
+++ b/src/tools/handlers/BaseToolHandler.ts
@@ -1,0 +1,29 @@
+// src/tools/handlers/BaseToolHandler.ts
+
+import type {KnowledgeGraphManager} from '../../types/managers.js';
+import type {ToolResponse} from '../../types/tools.js';
+import {formatToolError} from '../../utils/responseFormatter.js';
+
+export abstract class BaseToolHandler {
+    constructor(protected knowledgeGraphManager: KnowledgeGraphManager) {
+    }
+
+    abstract handleTool(name: string, args: Record<string, any>): Promise<ToolResponse>;
+
+    protected validateArguments(args: Record<string, any>): void {
+        if (!args) {
+            throw new Error("Tool arguments are required");
+        }
+    }
+
+    protected handleError(name: string, error: unknown): ToolResponse {
+        console.error(`Error in ${name}:`, error);
+        return formatToolError({
+            operation: name,
+            error: error instanceof Error ? error.message : 'Unknown error occurred',
+            context: {toolName: name},
+            suggestions: ["Examine the tool input parameters for correctness.", "Verify that the requested operation is supported."],
+            recoverySteps: ["Adjust the input parameters based on the schema definition."]
+        });
+    }
+}

--- a/src/tools/handlers/DynamicToolHandler.ts
+++ b/src/tools/handlers/DynamicToolHandler.ts
@@ -1,0 +1,30 @@
+// src/tools/handlers/DynamicToolHandler.ts
+
+import {BaseToolHandler} from './BaseToolHandler.js';
+import {dynamicTools} from '../tools.js';
+import {formatToolResponse} from '../../utils/responseFormatter.js';
+import type {ToolResponse} from '../../types/tools.js';
+
+export class DynamicToolHandler extends BaseToolHandler {
+    async handleTool(name: string, args: Record<string, any>): Promise<ToolResponse> {
+        try {
+            this.validateArguments(args);
+
+            const toolResult = await dynamicTools.handleToolCall(name, args, this.knowledgeGraphManager);
+
+            // If the result is already formatted as a ToolResponse, return it directly
+            if (toolResult?.toolResult?.isError !== undefined) {
+                return toolResult;
+            }
+
+            // Otherwise, format the result
+            return formatToolResponse({
+                data: toolResult,
+                message: `Successfully executed tool: ${name}`,
+                actionTaken: `Executed tool: ${name}`
+            });
+        } catch (error) {
+            return this.handleError(name, error);
+        }
+    }
+}

--- a/src/tools/handlers/GraphToolHandler.ts
+++ b/src/tools/handlers/GraphToolHandler.ts
@@ -1,0 +1,62 @@
+// src/tools/handlers/GraphToolHandler.ts
+
+import {BaseToolHandler} from './BaseToolHandler.js';
+import {formatToolResponse} from '../../utils/responseFormatter.js';
+import type {ToolResponse} from '../../types/tools.js';
+
+export class GraphToolHandler extends BaseToolHandler {
+    async handleTool(name: string, args: Record<string, any>): Promise<ToolResponse> {
+        try {
+            this.validateArguments(args);
+
+            switch (name) {
+                case "add_nodes":
+                    return formatToolResponse({
+                        data: {nodes: await this.knowledgeGraphManager.addNodes(args.nodes)},
+                        message: `Successfully added ${args.nodes.length} nodes`,
+                        actionTaken: "Added nodes to the knowledge graph"
+                    });
+
+                case "update_nodes":
+                    return formatToolResponse({
+                        data: {nodes: await this.knowledgeGraphManager.updateNodes(args.nodes)},
+                        message: `Successfully updated ${args.nodes.length} nodes`,
+                        actionTaken: "Updated nodes in the knowledge graph"
+                    });
+
+                case "add_edges":
+                    return formatToolResponse({
+                        data: {edges: await this.knowledgeGraphManager.addEdges(args.edges)},
+                        message: `Successfully added ${args.edges.length} edges`,
+                        actionTaken: "Added edges to the knowledge graph"
+                    });
+
+                case "update_edges":
+                    return formatToolResponse({
+                        data: {edges: await this.knowledgeGraphManager.updateEdges(args.edges)},
+                        message: `Successfully updated ${args.edges.length} edges`,
+                        actionTaken: "Updated edges in the knowledge graph"
+                    });
+
+                case "delete_nodes":
+                    await this.knowledgeGraphManager.deleteNodes(args.nodeNames);
+                    return formatToolResponse({
+                        message: `Successfully deleted nodes: ${args.nodeNames.join(', ')}`,
+                        actionTaken: "Deleted nodes from the knowledge graph"
+                    });
+
+                case "delete_edges":
+                    await this.knowledgeGraphManager.deleteEdges(args.edges);
+                    return formatToolResponse({
+                        message: `Successfully deleted edges`,
+                        actionTaken: "Deleted edges from the knowledge graph"
+                    });
+
+                default:
+                    throw new Error(`Unknown graph operation: ${name}`);
+            }
+        } catch (error) {
+            return this.handleError(name, error);
+        }
+    }
+}

--- a/src/tools/handlers/MetadataToolHandler.ts
+++ b/src/tools/handlers/MetadataToolHandler.ts
@@ -1,0 +1,34 @@
+// src/tools/handlers/MetadataToolHandler.ts
+
+import {BaseToolHandler} from './BaseToolHandler.js';
+import {formatToolResponse} from '../../utils/responseFormatter.js';
+import type {ToolResponse} from '../../types/tools.js';
+
+export class MetadataToolHandler extends BaseToolHandler {
+    async handleTool(name: string, args: Record<string, any>): Promise<ToolResponse> {
+        try {
+            this.validateArguments(args);
+
+            switch (name) {
+                case "add_metadata":
+                    return formatToolResponse({
+                        data: {metadata: await this.knowledgeGraphManager.addMetadata(args.metadata)},
+                        message: `Successfully added metadata`,
+                        actionTaken: "Added metadata to nodes in the knowledge graph"
+                    });
+
+                case "delete_metadata":
+                    await this.knowledgeGraphManager.deleteMetadata(args.deletions);
+                    return formatToolResponse({
+                        message: `Successfully deleted metadata`,
+                        actionTaken: "Deleted metadata from nodes in the knowledge graph"
+                    });
+
+                default:
+                    throw new Error(`Unknown metadata operation: ${name}`);
+            }
+        } catch (error) {
+            return this.handleError(name, error);
+        }
+    }
+}

--- a/src/tools/handlers/SearchToolHandler.ts
+++ b/src/tools/handlers/SearchToolHandler.ts
@@ -1,0 +1,41 @@
+// src/tools/handlers/SearchToolHandler.ts
+
+import {BaseToolHandler} from './BaseToolHandler.js';
+import {formatToolResponse} from '../../utils/responseFormatter.js';
+import type {ToolResponse} from '../../types/tools.js';
+
+export class SearchToolHandler extends BaseToolHandler {
+    async handleTool(name: string, args: Record<string, any>): Promise<ToolResponse> {
+        try {
+            this.validateArguments(args);
+
+            switch (name) {
+                case "read_graph":
+                    return formatToolResponse({
+                        data: await this.knowledgeGraphManager.readGraph(),
+                        message: `Successfully read the knowledge graph`,
+                        actionTaken: "Read the knowledge graph"
+                    });
+
+                case "search_nodes":
+                    return formatToolResponse({
+                        data: await this.knowledgeGraphManager.searchNodes(args.query),
+                        message: `Successfully searched nodes with query: ${args.query}`,
+                        actionTaken: "Searched nodes in the knowledge graph"
+                    });
+
+                case "open_nodes":
+                    return formatToolResponse({
+                        data: await this.knowledgeGraphManager.openNodes(args.names),
+                        message: `Successfully opened nodes: ${args.names.join(', ')}`,
+                        actionTaken: "Opened nodes in the knowledge graph"
+                    });
+
+                default:
+                    throw new Error(`Unknown search operation: ${name}`);
+            }
+        } catch (error) {
+            return this.handleError(name, error);
+        }
+    }
+}

--- a/src/tools/handlers/ToolHandlerFactory.ts
+++ b/src/tools/handlers/ToolHandlerFactory.ts
@@ -1,0 +1,42 @@
+// src/tools/handlers/ToolHandlerFactory.ts
+
+import {GraphToolHandler} from './GraphToolHandler.js';
+import {SearchToolHandler} from './SearchToolHandler.js';
+import {MetadataToolHandler} from './MetadataToolHandler.js';
+import {DynamicToolHandler} from './DynamicToolHandler.js';
+import type {KnowledgeGraphManager} from '../../types/managers.js';
+import type {BaseToolHandler} from './BaseToolHandler.js';
+
+export class ToolHandlerFactory {
+    private static graphHandler: GraphToolHandler;
+    private static searchHandler: SearchToolHandler;
+    private static metadataHandler: MetadataToolHandler;
+    private static dynamicHandler: DynamicToolHandler;
+
+    static initialize(knowledgeGraphManager: KnowledgeGraphManager): void {
+        this.graphHandler = new GraphToolHandler(knowledgeGraphManager);
+        this.searchHandler = new SearchToolHandler(knowledgeGraphManager);
+        this.metadataHandler = new MetadataToolHandler(knowledgeGraphManager);
+        this.dynamicHandler = new DynamicToolHandler(knowledgeGraphManager);
+    }
+
+    static getHandler(toolName: string): BaseToolHandler {
+        // First check for core tools
+        if (toolName.match(/^(add|update|delete)_(nodes|edges)$/)) {
+            return this.graphHandler;
+        }
+        if (toolName.match(/^(read_graph|search_nodes|open_nodes)$/)) {
+            return this.searchHandler;
+        }
+        if (toolName.match(/^(add|delete)_metadata$/)) {
+            return this.metadataHandler;
+        }
+
+        // If it's not a core tool, assume it's a dynamic tool
+        if (toolName.match(/^(add|update|delete)_/)) {
+            return this.dynamicHandler;
+        }
+
+        throw new Error(`No handler found for tool: ${toolName}`);
+    }
+}


### PR DESCRIPTION
v0.2.3
removed read graph caching
split KnowledgeGraphManager
split callToolHandler 