### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,11 +320,6 @@ To install MemoryMesh for Claude Desktop automatically via [Smithery](https://sm
 npx @smithery/cli install memorymesh --client claude
 ```
 
-### MemoryMesh on glama.ai
-<a href="https://glama.ai/mcp/servers/kf6n6221pd">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/kf6n6221pd/badge" />
-</a>
-
 ## Advanced Configuration
 MemoryMesh offers several ways to customize its behavior beyond the basic setup:
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ MemoryMesh is a knowledge graph server designed for AI models, with a focus on t
 
 *The project is based on the [Knowledge Graph Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) from the MCP servers repository and retains its core functionality.*
 
+<a href="https://glama.ai/mcp/servers/kf6n6221pd"><img width="380" height="200" src="https://glama.ai/mcp/servers/kf6n6221pd/badge" alt="MemoryMesh MCP server" /></a>
+
 ## IMPORTANT
 Since `v0.2.7` the default location of schemas was changed to `dist/data/schemas`.
 This location is not expected to change in the future, but if you are updating from a previous version, make sure to move your schema files to the new location.


### PR DESCRIPTION
This PR adds a badge for the MemoryMesh server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/kf6n6221pd"><img width="380" height="200" src="https://glama.ai/mcp/servers/kf6n6221pd/badge" alt="MemoryMesh MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.