### PR TITLE
refactor: Remove dead code from DynamicToolHandler

### DIFF
--- a/src/integration/tools/handlers/DynamicToolHandler.ts
+++ b/src/integration/tools/handlers/DynamicToolHandler.ts
@@ -2,7 +2,7 @@
 
 import {BaseToolHandler} from './BaseToolHandler.js';
 import {dynamicToolManager} from '@integration/index.js';
-import {formatToolResponse, formatToolError} from '@shared/index.js';
+import {formatToolError} from '@shared/index.js';
 import type {ToolResponse} from '@shared/index.js';
 
 export class DynamicToolHandler extends BaseToolHandler {
@@ -10,16 +10,8 @@ export class DynamicToolHandler extends BaseToolHandler {
         try {
             this.validateArguments(args);
 
-            const toolResult = await dynamicToolManager.handleToolCall(name, args, this.knowledgeGraphManager);
-
-            if (toolResult?.toolResult?.isError !== undefined) {
-                return toolResult;
-            }
-
-            return formatToolResponse({
-                data: toolResult,
-                actionTaken: `Executed dynamic tool: ${name}`
-            });
+            // Response is already formatted by dynamicToolManager
+            return await dynamicToolManager.handleToolCall(name, args, this.knowledgeGraphManager);
         } catch (error) {
             return formatToolError({
                 operation: name,


### PR DESCRIPTION
Simplify response handling logic by removing unnecessary conditional check and dead code. The response is already formatted by dynamicToolManager.handleToolCall, so the extra wrapping and check were redundant and confusing.

Changes:
- Remove unreachable formatToolResponse call (lines 19-22)
- Remove pointless isError check (always true)
- Return response directly from dynamicToolManager
- Remove unused formatToolResponse import

This makes the code clearer and easier to understand.