### PR TITLE
test: Add comprehensive test suite with Vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,73 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
+        "@vitest/coverage-v8": "^4.0.17",
         "copyfiles": "^2.4.1",
         "shx": "^0.3.4",
         "ts-node": "^10.9.2",
         "tsc-alias": "^1.8.10",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "vitest": "^4.0.17"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.6"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -35,6 +97,448 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -60,9 +564,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -154,6 +658,363 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -182,6 +1043,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
@@ -190,6 +1076,148 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.17.tgz",
+      "integrity": "sha512-/6zU2FLGg0jsd+ePZcwHRy3+WpNTBBhDY56P4JTRqUN/Dp6CvOEa9HrikcQ4KfV2b2kAHUFB4dl1SuocWXSFEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.17",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.17",
+        "vitest": "4.0.17"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
+      "integrity": "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.17",
+        "@vitest/utils": "4.0.17",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.17.tgz",
+      "integrity": "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.17",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
+      "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.17.tgz",
+      "integrity": "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.17.tgz",
+      "integrity": "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.17",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.17.tgz",
+      "integrity": "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
+      "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.17",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -321,6 +1349,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
+      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^9.0.1"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -423,6 +1484,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -699,6 +1770,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -709,6 +1787,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
       }
     },
     "node_modules/escalade": {
@@ -726,6 +1846,16 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -755,6 +1885,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1062,6 +2202,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1095,6 +2245,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1268,6 +2425,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
@@ -1276,6 +2472,13 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -1288,6 +2491,44 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
+      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1431,6 +2672,25 @@
         "url": "https://github.com/sponsors/raouldeheer"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1481,6 +2741,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -1558,6 +2829,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1591,6 +2876,35 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/process-nextick-args": {
@@ -1769,6 +3083,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1819,6 +3178,19 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1997,6 +3369,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2007,6 +3386,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2015,6 +3411,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "0.10.31",
@@ -2046,6 +3449,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -2106,6 +3522,81 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -2265,6 +3756,203 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.17.tgz",
+      "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.17",
+        "@vitest/mocker": "4.0.17",
+        "@vitest/pretty-format": "4.0.17",
+        "@vitest/runner": "4.0.17",
+        "@vitest/snapshot": "4.0.17",
+        "@vitest/spy": "4.0.17",
+        "@vitest/utils": "4.0.17",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.17",
+        "@vitest/browser-preview": "4.0.17",
+        "@vitest/browser-webdriverio": "4.0.17",
+        "@vitest/ui": "4.0.17",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2278,6 +3966,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
     "watch": "tsc --watch",
     "start": "ts-node --esm src/index.ts",
     "start:claude": "ts-node --esm src/index.ts",
-    "start:prod": "node dist/index.js"
+    "start:prod": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
@@ -28,10 +32,12 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.5",
+    "@vitest/coverage-v8": "^4.0.17",
     "copyfiles": "^2.4.1",
     "shx": "^0.3.4",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.17"
   }
 }

--- a/tests/unit/graph/edgeWeightUtils.test.ts
+++ b/tests/unit/graph/edgeWeightUtils.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { EdgeWeightUtils } from '../../../src/core/graph/EdgeWeightUtils.js';
+import type { Edge } from '../../../src/core/graph/Edge.js';
+
+describe('EdgeWeightUtils', () => {
+    const createEdge = (from: string, to: string, edgeType: string, weight?: number): Edge => ({
+        type: 'edge',
+        from,
+        to,
+        edgeType,
+        ...(weight !== undefined && { weight })
+    });
+
+    describe('validateWeight', () => {
+        it('should accept weight of 0', () => {
+            expect(() => EdgeWeightUtils.validateWeight(0)).not.toThrow();
+        });
+
+        it('should accept weight of 1', () => {
+            expect(() => EdgeWeightUtils.validateWeight(1)).not.toThrow();
+        });
+
+        it('should accept weight between 0 and 1', () => {
+            expect(() => EdgeWeightUtils.validateWeight(0.5)).not.toThrow();
+            expect(() => EdgeWeightUtils.validateWeight(0.1)).not.toThrow();
+            expect(() => EdgeWeightUtils.validateWeight(0.99)).not.toThrow();
+        });
+
+        it('should reject negative weight', () => {
+            expect(() => EdgeWeightUtils.validateWeight(-0.1))
+                .toThrow('Edge weight must be between 0 and 1');
+        });
+
+        it('should reject weight greater than 1', () => {
+            expect(() => EdgeWeightUtils.validateWeight(1.1))
+                .toThrow('Edge weight must be between 0 and 1');
+        });
+    });
+
+    describe('ensureWeight', () => {
+        it('should add default weight of 1 when weight is undefined', () => {
+            const edge = createEdge('a', 'b', 'knows');
+            const result = EdgeWeightUtils.ensureWeight(edge);
+
+            expect(result.weight).toBe(1);
+        });
+
+        it('should preserve existing weight', () => {
+            const edge = createEdge('a', 'b', 'knows', 0.5);
+            const result = EdgeWeightUtils.ensureWeight(edge);
+
+            expect(result.weight).toBe(0.5);
+        });
+
+        it('should preserve weight of 0', () => {
+            const edge = createEdge('a', 'b', 'knows', 0);
+            const result = EdgeWeightUtils.ensureWeight(edge);
+
+            expect(result.weight).toBe(0);
+        });
+
+        it('should not mutate original edge', () => {
+            const edge = createEdge('a', 'b', 'knows');
+            EdgeWeightUtils.ensureWeight(edge);
+
+            expect(edge.weight).toBeUndefined();
+        });
+
+        it('should preserve all other edge properties', () => {
+            const edge = createEdge('a', 'b', 'knows');
+            const result = EdgeWeightUtils.ensureWeight(edge);
+
+            expect(result.from).toBe('a');
+            expect(result.to).toBe('b');
+            expect(result.edgeType).toBe('knows');
+            expect(result.type).toBe('edge');
+        });
+    });
+
+    describe('updateWeight', () => {
+        it('should average current weight with new evidence', () => {
+            const result = EdgeWeightUtils.updateWeight(0.8, 0.4);
+
+            expect(result).toBeCloseTo(0.6); // (0.8 + 0.4) / 2
+        });
+
+        it('should handle equal weights', () => {
+            const result = EdgeWeightUtils.updateWeight(0.5, 0.5);
+
+            expect(result).toBe(0.5);
+        });
+
+        it('should handle zero current weight', () => {
+            const result = EdgeWeightUtils.updateWeight(0, 1);
+
+            expect(result).toBe(0.5);
+        });
+
+        it('should handle zero new evidence', () => {
+            const result = EdgeWeightUtils.updateWeight(1, 0);
+
+            expect(result).toBe(0.5);
+        });
+
+        it('should validate new evidence weight', () => {
+            expect(() => EdgeWeightUtils.updateWeight(0.5, 1.5))
+                .toThrow('Edge weight must be between 0 and 1');
+        });
+
+        it('should validate negative new evidence', () => {
+            expect(() => EdgeWeightUtils.updateWeight(0.5, -0.1))
+                .toThrow('Edge weight must be between 0 and 1');
+        });
+    });
+
+    describe('combineWeights', () => {
+        it('should return maximum weight', () => {
+            const result = EdgeWeightUtils.combineWeights([0.3, 0.7, 0.5]);
+
+            expect(result).toBe(0.7);
+        });
+
+        it('should return 1 for empty array', () => {
+            const result = EdgeWeightUtils.combineWeights([]);
+
+            expect(result).toBe(1);
+        });
+
+        it('should handle single weight', () => {
+            const result = EdgeWeightUtils.combineWeights([0.5]);
+
+            expect(result).toBe(0.5);
+        });
+
+        it('should handle all same weights', () => {
+            const result = EdgeWeightUtils.combineWeights([0.5, 0.5, 0.5]);
+
+            expect(result).toBe(0.5);
+        });
+
+        it('should handle weight of 0', () => {
+            const result = EdgeWeightUtils.combineWeights([0, 0, 0]);
+
+            expect(result).toBe(0);
+        });
+
+        it('should handle mixed weights including 0 and 1', () => {
+            const result = EdgeWeightUtils.combineWeights([0, 0.5, 1]);
+
+            expect(result).toBe(1);
+        });
+    });
+});

--- a/tests/unit/graph/graphValidator.test.ts
+++ b/tests/unit/graph/graphValidator.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { GraphValidator } from '../../../src/core/graph/GraphValidator.js';
+import type { Graph } from '../../../src/core/graph/Graph.js';
+import type { Node } from '../../../src/core/graph/Node.js';
+import type { Edge } from '../../../src/core/graph/Edge.js';
+
+describe('GraphValidator', () => {
+    const createNode = (name: string, nodeType: string = 'test'): Node => ({
+        type: 'node',
+        name,
+        nodeType,
+        metadata: []
+    });
+
+    const createEdge = (from: string, to: string, edgeType: string = 'related'): Edge => ({
+        type: 'edge',
+        from,
+        to,
+        edgeType
+    });
+
+    const createGraph = (nodes: Node[] = [], edges: Edge[] = []): Graph => ({
+        nodes,
+        edges
+    });
+
+    describe('validateNodeExists', () => {
+        it('should pass when node exists', () => {
+            const graph = createGraph([createNode('test')]);
+
+            expect(() => GraphValidator.validateNodeExists(graph, 'test')).not.toThrow();
+        });
+
+        it('should throw when node does not exist', () => {
+            const graph = createGraph([]);
+
+            expect(() => GraphValidator.validateNodeExists(graph, 'missing'))
+                .toThrow('Node not found: missing');
+        });
+    });
+
+    describe('validateNodeDoesNotExist', () => {
+        it('should pass when node does not exist', () => {
+            const graph = createGraph([]);
+
+            expect(() => GraphValidator.validateNodeDoesNotExist(graph, 'new')).not.toThrow();
+        });
+
+        it('should throw when node already exists', () => {
+            const graph = createGraph([createNode('existing')]);
+
+            expect(() => GraphValidator.validateNodeDoesNotExist(graph, 'existing'))
+                .toThrow('Node already exists: existing');
+        });
+    });
+
+    describe('validateEdgeUniqueness', () => {
+        it('should pass for unique edge', () => {
+            const graph = createGraph([createNode('a'), createNode('b')]);
+            const edge = createEdge('a', 'b', 'knows');
+
+            expect(() => GraphValidator.validateEdgeUniqueness(graph, edge)).not.toThrow();
+        });
+
+        it('should throw for duplicate edge', () => {
+            const edge = createEdge('a', 'b', 'knows');
+            const graph = createGraph([createNode('a'), createNode('b')], [edge]);
+
+            expect(() => GraphValidator.validateEdgeUniqueness(graph, edge))
+                .toThrow('Edge already exists: a -> b (knows)');
+        });
+
+        it('should allow different edge types between same nodes', () => {
+            const edge1 = createEdge('a', 'b', 'knows');
+            const edge2 = createEdge('a', 'b', 'likes');
+            const graph = createGraph([createNode('a'), createNode('b')], [edge1]);
+
+            expect(() => GraphValidator.validateEdgeUniqueness(graph, edge2)).not.toThrow();
+        });
+    });
+
+    describe('validateNodeProperties', () => {
+        it('should pass for valid node', () => {
+            const node = createNode('valid', 'npc');
+
+            expect(() => GraphValidator.validateNodeProperties(node)).not.toThrow();
+        });
+
+        it('should throw for node without name', () => {
+            const node = { type: 'node', name: '', nodeType: 'npc', metadata: [] } as Node;
+
+            expect(() => GraphValidator.validateNodeProperties(node))
+                .toThrow("Node must have a 'name' property");
+        });
+
+        it('should throw for node without nodeType', () => {
+            const node = { type: 'node', name: 'test', nodeType: '', metadata: [] } as Node;
+
+            expect(() => GraphValidator.validateNodeProperties(node))
+                .toThrow("Node must have a 'nodeType' property");
+        });
+
+        it('should throw for node without metadata array', () => {
+            const node = { type: 'node', name: 'test', nodeType: 'npc', metadata: null } as any;
+
+            expect(() => GraphValidator.validateNodeProperties(node))
+                .toThrow("Node must have a 'metadata' array");
+        });
+    });
+
+    describe('validateNodeNameProperty', () => {
+        it('should pass for partial node with name', () => {
+            const partialNode = { name: 'test' };
+
+            expect(() => GraphValidator.validateNodeNameProperty(partialNode)).not.toThrow();
+        });
+
+        it('should throw for partial node without name', () => {
+            const partialNode = { nodeType: 'npc' };
+
+            expect(() => GraphValidator.validateNodeNameProperty(partialNode))
+                .toThrow("Node must have a 'name' property for updating");
+        });
+    });
+
+    describe('validateNodeNamesArray', () => {
+        it('should pass for valid array of strings', () => {
+            const names = ['node1', 'node2', 'node3'];
+
+            expect(() => GraphValidator.validateNodeNamesArray(names)).not.toThrow();
+        });
+
+        it('should throw for non-array input', () => {
+            expect(() => GraphValidator.validateNodeNamesArray('not-an-array'))
+                .toThrow('nodeNames must be an array');
+        });
+
+        it('should throw for array with non-string elements', () => {
+            const invalid = ['valid', 123, 'also-valid'];
+
+            expect(() => GraphValidator.validateNodeNamesArray(invalid))
+                .toThrow('All node names must be strings');
+        });
+
+        it('should pass for empty array', () => {
+            expect(() => GraphValidator.validateNodeNamesArray([])).not.toThrow();
+        });
+    });
+
+    describe('validateEdgeProperties', () => {
+        it('should pass for valid edge', () => {
+            const edge = createEdge('a', 'b', 'knows');
+
+            expect(() => GraphValidator.validateEdgeProperties(edge)).not.toThrow();
+        });
+
+        it('should throw for edge without from', () => {
+            const edge = { type: 'edge', from: '', to: 'b', edgeType: 'knows' } as Edge;
+
+            expect(() => GraphValidator.validateEdgeProperties(edge))
+                .toThrow("Edge must have a 'from' property");
+        });
+
+        it('should throw for edge without to', () => {
+            const edge = { type: 'edge', from: 'a', to: '', edgeType: 'knows' } as Edge;
+
+            expect(() => GraphValidator.validateEdgeProperties(edge))
+                .toThrow("Edge must have a 'to' property");
+        });
+
+        it('should throw for edge without edgeType', () => {
+            const edge = { type: 'edge', from: 'a', to: 'b', edgeType: '' } as Edge;
+
+            expect(() => GraphValidator.validateEdgeProperties(edge))
+                .toThrow("Edge must have an 'edgeType' property");
+        });
+
+        it('should pass for edge with valid weight', () => {
+            const edge = { ...createEdge('a', 'b', 'knows'), weight: 0.5 };
+
+            expect(() => GraphValidator.validateEdgeProperties(edge)).not.toThrow();
+        });
+
+        it('should throw for edge with invalid weight', () => {
+            const edge = { ...createEdge('a', 'b', 'knows'), weight: 1.5 };
+
+            expect(() => GraphValidator.validateEdgeProperties(edge))
+                .toThrow('Edge weight must be between 0 and 1');
+        });
+    });
+
+    describe('validateEdgeReferences', () => {
+        it('should pass when all edge references exist', () => {
+            const graph = createGraph([createNode('a'), createNode('b')]);
+            const edges = [createEdge('a', 'b', 'knows')];
+
+            expect(() => GraphValidator.validateEdgeReferences(graph, edges)).not.toThrow();
+        });
+
+        it('should throw when from node does not exist', () => {
+            const graph = createGraph([createNode('b')]);
+            const edges = [createEdge('missing', 'b', 'knows')];
+
+            expect(() => GraphValidator.validateEdgeReferences(graph, edges))
+                .toThrow('Node not found: missing');
+        });
+
+        it('should throw when to node does not exist', () => {
+            const graph = createGraph([createNode('a')]);
+            const edges = [createEdge('a', 'missing', 'knows')];
+
+            expect(() => GraphValidator.validateEdgeReferences(graph, edges))
+                .toThrow('Node not found: missing');
+        });
+    });
+
+    describe('validateGraphStructure', () => {
+        it('should pass for valid graph', () => {
+            const graph = createGraph(
+                [createNode('a'), createNode('b')],
+                [createEdge('a', 'b', 'knows')]
+            );
+
+            expect(() => GraphValidator.validateGraphStructure(graph)).not.toThrow();
+        });
+
+        it('should pass for empty graph', () => {
+            const graph = createGraph();
+
+            expect(() => GraphValidator.validateGraphStructure(graph)).not.toThrow();
+        });
+
+        it('should throw for graph without nodes array', () => {
+            const graph = { edges: [] } as any;
+
+            expect(() => GraphValidator.validateGraphStructure(graph))
+                .toThrow("Graph must have a 'nodes' array");
+        });
+
+        it('should throw for graph without edges array', () => {
+            const graph = { nodes: [] } as any;
+
+            expect(() => GraphValidator.validateGraphStructure(graph))
+                .toThrow("Graph must have an 'edges' array");
+        });
+
+        it('should validate all nodes in graph', () => {
+            const graph = createGraph([
+                createNode('valid'),
+                { type: 'node', name: '', nodeType: 'npc', metadata: [] } as Node
+            ]);
+
+            expect(() => GraphValidator.validateGraphStructure(graph)).toThrow();
+        });
+
+        it('should validate edge references', () => {
+            const graph = createGraph(
+                [createNode('a')],
+                [createEdge('a', 'missing', 'knows')]
+            );
+
+            expect(() => GraphValidator.validateGraphStructure(graph))
+                .toThrow('Node not found: missing');
+        });
+    });
+});

--- a/tests/unit/handlers/graphToolHandler.test.ts
+++ b/tests/unit/handlers/graphToolHandler.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GraphToolHandler } from '../../../src/integration/tools/handlers/GraphToolHandler.js';
+import type { ApplicationManager } from '../../../src/application/managers/ApplicationManager.js';
+import type { Node, Edge } from '../../../src/core/graph/index.js';
+
+// Mock ApplicationManager
+const createMockApplicationManager = (): ApplicationManager => ({
+    addNodes: vi.fn(),
+    updateNodes: vi.fn(),
+    deleteNodes: vi.fn(),
+    addEdges: vi.fn(),
+    updateEdges: vi.fn(),
+    deleteEdges: vi.fn(),
+    getEdges: vi.fn(),
+    addMetadata: vi.fn(),
+    deleteMetadata: vi.fn(),
+    readGraph: vi.fn(),
+    searchNodes: vi.fn(),
+    openNodes: vi.fn(),
+    beginTransaction: vi.fn(),
+    commit: vi.fn(),
+    rollback: vi.fn(),
+    withTransaction: vi.fn(),
+    addRollbackAction: vi.fn(),
+    isInTransaction: vi.fn(),
+    getCurrentGraph: vi.fn(),
+} as unknown as ApplicationManager);
+
+describe('GraphToolHandler', () => {
+    let handler: GraphToolHandler;
+    let mockManager: ApplicationManager;
+
+    beforeEach(() => {
+        mockManager = createMockApplicationManager();
+        handler = new GraphToolHandler(mockManager);
+    });
+
+    describe('add_nodes', () => {
+        it('should add nodes successfully', async () => {
+            const nodes: Node[] = [
+                { type: 'node', name: 'test', nodeType: 'npc', metadata: ['info'] }
+            ];
+            vi.mocked(mockManager.addNodes).mockResolvedValue(nodes);
+
+            const result = await handler.handleTool('add_nodes', { nodes });
+
+            expect(mockManager.addNodes).toHaveBeenCalledWith(nodes);
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data?.nodes).toEqual(nodes);
+            expect(result.structuredContent?.actionTaken).toContain('Added nodes');
+        });
+
+        it('should return error when addNodes fails', async () => {
+            vi.mocked(mockManager.addNodes).mockRejectedValue(new Error('Database error'));
+
+            const result = await handler.handleTool('add_nodes', {
+                nodes: [{ name: 'test', nodeType: 'npc', metadata: [] }]
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Database error');
+        });
+    });
+
+    describe('update_nodes', () => {
+        it('should update nodes successfully', async () => {
+            const nodes: Node[] = [
+                { type: 'node', name: 'test', nodeType: 'npc', metadata: ['updated'] }
+            ];
+            vi.mocked(mockManager.updateNodes).mockResolvedValue(nodes);
+
+            const result = await handler.handleTool('update_nodes', {
+                nodes: [{ name: 'test', metadata: ['updated'] }]
+            });
+
+            expect(mockManager.updateNodes).toHaveBeenCalled();
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.actionTaken).toContain('Updated nodes');
+        });
+    });
+
+    describe('add_edges', () => {
+        it('should add edges successfully', async () => {
+            const edges: Edge[] = [
+                { type: 'edge', from: 'a', to: 'b', edgeType: 'knows' }
+            ];
+            vi.mocked(mockManager.addEdges).mockResolvedValue(edges);
+
+            const result = await handler.handleTool('add_edges', { edges });
+
+            expect(mockManager.addEdges).toHaveBeenCalledWith(edges);
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data?.edges).toEqual(edges);
+        });
+
+        it('should handle edges with weight', async () => {
+            const edges: Edge[] = [
+                { type: 'edge', from: 'a', to: 'b', edgeType: 'knows', weight: 0.8 }
+            ];
+            vi.mocked(mockManager.addEdges).mockResolvedValue(edges);
+
+            const result = await handler.handleTool('add_edges', { edges });
+
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data?.edges[0].weight).toBe(0.8);
+        });
+    });
+
+    describe('update_edges', () => {
+        it('should update edges successfully', async () => {
+            const edges: Edge[] = [
+                { type: 'edge', from: 'a', to: 'b', edgeType: 'friends' }
+            ];
+            vi.mocked(mockManager.updateEdges).mockResolvedValue(edges);
+
+            const result = await handler.handleTool('update_edges', {
+                edges: [{ from: 'a', to: 'b', edgeType: 'knows', newEdgeType: 'friends' }]
+            });
+
+            expect(mockManager.updateEdges).toHaveBeenCalled();
+            expect(result.isError).toBe(false);
+        });
+    });
+
+    describe('delete_nodes', () => {
+        it('should delete nodes successfully', async () => {
+            vi.mocked(mockManager.deleteNodes).mockResolvedValue(undefined);
+
+            const result = await handler.handleTool('delete_nodes', {
+                nodeNames: ['node1', 'node2']
+            });
+
+            expect(mockManager.deleteNodes).toHaveBeenCalledWith(['node1', 'node2']);
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.actionTaken).toContain('node1');
+            expect(result.structuredContent?.actionTaken).toContain('node2');
+        });
+    });
+
+    describe('delete_edges', () => {
+        it('should delete edges successfully', async () => {
+            vi.mocked(mockManager.deleteEdges).mockResolvedValue(undefined);
+
+            const edges = [{ from: 'a', to: 'b', edgeType: 'knows' }];
+            const result = await handler.handleTool('delete_edges', { edges });
+
+            expect(mockManager.deleteEdges).toHaveBeenCalledWith(edges);
+            expect(result.isError).toBe(false);
+        });
+    });
+
+    describe('unknown operation', () => {
+        it('should throw error for unknown tool name', async () => {
+            const result = await handler.handleTool('unknown_tool', {});
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Unknown graph operation');
+        });
+    });
+
+    describe('argument validation', () => {
+        it('should handle null arguments', async () => {
+            const result = await handler.handleTool('add_nodes', null as any);
+
+            expect(result.isError).toBe(true);
+        });
+
+        it('should handle undefined arguments', async () => {
+            const result = await handler.handleTool('add_nodes', undefined as any);
+
+            expect(result.isError).toBe(true);
+        });
+    });
+
+    describe('error response format', () => {
+        it('should include suggestions in error response', async () => {
+            vi.mocked(mockManager.addNodes).mockRejectedValue(new Error('Failed'));
+
+            const result = await handler.handleTool('add_nodes', { nodes: [] });
+
+            expect(result.structuredContent?.suggestions).toBeDefined();
+            expect(Array.isArray(result.structuredContent?.suggestions)).toBe(true);
+        });
+
+        it('should include recovery steps in error response', async () => {
+            vi.mocked(mockManager.addNodes).mockRejectedValue(new Error('Failed'));
+
+            const result = await handler.handleTool('add_nodes', { nodes: [] });
+
+            expect(result.structuredContent?.recoverySteps).toBeDefined();
+            expect(Array.isArray(result.structuredContent?.recoverySteps)).toBe(true);
+        });
+    });
+});

--- a/tests/unit/handlers/searchToolHandler.test.ts
+++ b/tests/unit/handlers/searchToolHandler.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SearchToolHandler } from '../../../src/integration/tools/handlers/SearchToolHandler.js';
+import type { ApplicationManager } from '../../../src/application/managers/ApplicationManager.js';
+import type { Graph } from '../../../src/core/graph/index.js';
+
+// Mock ApplicationManager
+const createMockApplicationManager = (): ApplicationManager => ({
+    addNodes: vi.fn(),
+    updateNodes: vi.fn(),
+    deleteNodes: vi.fn(),
+    addEdges: vi.fn(),
+    updateEdges: vi.fn(),
+    deleteEdges: vi.fn(),
+    getEdges: vi.fn(),
+    addMetadata: vi.fn(),
+    deleteMetadata: vi.fn(),
+    readGraph: vi.fn(),
+    searchNodes: vi.fn(),
+    openNodes: vi.fn(),
+    beginTransaction: vi.fn(),
+    commit: vi.fn(),
+    rollback: vi.fn(),
+    withTransaction: vi.fn(),
+    addRollbackAction: vi.fn(),
+    isInTransaction: vi.fn(),
+    getCurrentGraph: vi.fn(),
+} as unknown as ApplicationManager);
+
+describe('SearchToolHandler', () => {
+    let handler: SearchToolHandler;
+    let mockManager: ApplicationManager;
+
+    beforeEach(() => {
+        mockManager = createMockApplicationManager();
+        handler = new SearchToolHandler(mockManager);
+    });
+
+    describe('read_graph', () => {
+        it('should return entire graph successfully', async () => {
+            const mockGraph: Graph = {
+                nodes: [
+                    { type: 'node', name: 'node1', nodeType: 'npc', metadata: ['info'] }
+                ],
+                edges: [
+                    { type: 'edge', from: 'node1', to: 'node2', edgeType: 'knows' }
+                ]
+            };
+            vi.mocked(mockManager.readGraph).mockResolvedValue(mockGraph);
+
+            const result = await handler.handleTool('read_graph', {});
+
+            expect(mockManager.readGraph).toHaveBeenCalled();
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data).toEqual(mockGraph);
+            expect(result.structuredContent?.actionTaken).toContain('Read complete knowledge graph');
+        });
+
+        it('should handle empty graph', async () => {
+            const emptyGraph: Graph = { nodes: [], edges: [] };
+            vi.mocked(mockManager.readGraph).mockResolvedValue(emptyGraph);
+
+            const result = await handler.handleTool('read_graph', {});
+
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data.nodes).toHaveLength(0);
+            expect(result.structuredContent?.data.edges).toHaveLength(0);
+        });
+
+        it('should handle read errors', async () => {
+            vi.mocked(mockManager.readGraph).mockRejectedValue(new Error('Storage error'));
+
+            const result = await handler.handleTool('read_graph', {});
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Storage error');
+        });
+    });
+
+    describe('search_nodes', () => {
+        it('should search nodes with query', async () => {
+            const searchResult = {
+                nodes: [
+                    { type: 'node' as const, name: 'dragon', nodeType: 'creature', metadata: ['Fire breathing'] }
+                ],
+                edges: []
+            };
+            vi.mocked(mockManager.searchNodes).mockResolvedValue(searchResult);
+
+            const result = await handler.handleTool('search_nodes', { query: 'dragon' });
+
+            expect(mockManager.searchNodes).toHaveBeenCalledWith('dragon');
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data).toEqual(searchResult);
+            expect(result.structuredContent?.actionTaken).toContain('dragon');
+        });
+
+        it('should handle empty search results', async () => {
+            vi.mocked(mockManager.searchNodes).mockResolvedValue({ nodes: [], edges: [] });
+
+            const result = await handler.handleTool('search_nodes', { query: 'nonexistent' });
+
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data.nodes).toHaveLength(0);
+        });
+
+        it('should handle search errors', async () => {
+            vi.mocked(mockManager.searchNodes).mockRejectedValue(new Error('Search failed'));
+
+            const result = await handler.handleTool('search_nodes', { query: 'test' });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Search failed');
+        });
+    });
+
+    describe('open_nodes', () => {
+        it('should open specific nodes by name', async () => {
+            const openResult = {
+                nodes: [
+                    { type: 'node' as const, name: 'hero', nodeType: 'npc', metadata: ['Brave'] },
+                    { type: 'node' as const, name: 'village', nodeType: 'location', metadata: ['Peaceful'] }
+                ],
+                edges: [
+                    { type: 'edge' as const, from: 'hero', to: 'village', edgeType: 'lives_in' }
+                ]
+            };
+            vi.mocked(mockManager.openNodes).mockResolvedValue(openResult);
+
+            const result = await handler.handleTool('open_nodes', { names: ['hero', 'village'] });
+
+            expect(mockManager.openNodes).toHaveBeenCalledWith(['hero', 'village']);
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data).toEqual(openResult);
+            expect(result.structuredContent?.actionTaken).toContain('hero');
+            expect(result.structuredContent?.actionTaken).toContain('village');
+        });
+
+        it('should handle single node', async () => {
+            const openResult = {
+                nodes: [
+                    { type: 'node' as const, name: 'castle', nodeType: 'location', metadata: ['Grand'] }
+                ],
+                edges: []
+            };
+            vi.mocked(mockManager.openNodes).mockResolvedValue(openResult);
+
+            const result = await handler.handleTool('open_nodes', { names: ['castle'] });
+
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data.nodes).toHaveLength(1);
+        });
+
+        it('should handle non-existent nodes gracefully', async () => {
+            vi.mocked(mockManager.openNodes).mockResolvedValue({ nodes: [], edges: [] });
+
+            const result = await handler.handleTool('open_nodes', { names: ['nonexistent'] });
+
+            expect(result.isError).toBe(false);
+            expect(result.structuredContent?.data.nodes).toHaveLength(0);
+        });
+
+        it('should handle open errors', async () => {
+            vi.mocked(mockManager.openNodes).mockRejectedValue(new Error('Node access denied'));
+
+            const result = await handler.handleTool('open_nodes', { names: ['secret'] });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Node access denied');
+        });
+    });
+
+    describe('unknown operation', () => {
+        it('should throw error for unknown tool name', async () => {
+            const result = await handler.handleTool('unknown_search_tool', { query: 'test' });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Unknown search operation');
+        });
+    });
+
+    describe('error response format', () => {
+        it('should include suggestions in error response', async () => {
+            vi.mocked(mockManager.searchNodes).mockRejectedValue(new Error('Failed'));
+
+            const result = await handler.handleTool('search_nodes', { query: 'test' });
+
+            expect(result.structuredContent?.suggestions).toBeDefined();
+            expect(result.structuredContent?.suggestions?.length).toBeGreaterThan(0);
+        });
+
+        it('should include recovery steps in error response', async () => {
+            vi.mocked(mockManager.openNodes).mockRejectedValue(new Error('Failed'));
+
+            const result = await handler.handleTool('open_nodes', { names: ['test'] });
+
+            expect(result.structuredContent?.recoverySteps).toBeDefined();
+        });
+
+        it('should include context in error response', async () => {
+            vi.mocked(mockManager.searchNodes).mockRejectedValue(new Error('Failed'));
+
+            const result = await handler.handleTool('search_nodes', { query: 'dragon' });
+
+            // The error formatter includes args in context
+            expect(result.content.some(c => c.text.includes('dragon') || c.text.includes('args'))).toBe(true);
+        });
+    });
+});

--- a/tests/unit/schema/schemaBuilder.test.ts
+++ b/tests/unit/schema/schemaBuilder.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SchemaBuilder } from '../../../src/core/schema/SchemaBuilder.js';
+import type { SchemaConfig } from '../../../src/core/schema/SchemaBuilder.js';
+
+describe('SchemaBuilder', () => {
+    let builder: SchemaBuilder;
+
+    beforeEach(() => {
+        builder = new SchemaBuilder('add_npc', 'Add a new NPC to the knowledge graph');
+    });
+
+    describe('constructor', () => {
+        it('should initialize with name and description', () => {
+            const schema = builder.build();
+
+            expect(schema.name).toBe('add_npc');
+            expect(schema.description).toBe('Add a new NPC to the knowledge graph');
+        });
+
+        it('should create inputSchema with object type', () => {
+            const schema = builder.build();
+
+            expect(schema.inputSchema.type).toBe('object');
+        });
+
+        it('should create nested property structure using schema name', () => {
+            const schema = builder.build();
+
+            expect(schema.inputSchema.properties).toHaveProperty('npc');
+            expect(schema.inputSchema.required).toContain('npc');
+        });
+    });
+
+    describe('addStringProperty', () => {
+        it('should add a required string property', () => {
+            builder.addStringProperty('name', 'The name of the NPC', true);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.name).toBeDefined();
+            expect(npcProps.properties.name.type).toBe('string');
+            expect(npcProps.properties.name.description).toBe('The name of the NPC');
+            expect(npcProps.required).toContain('name');
+        });
+
+        it('should add an optional string property', () => {
+            builder.addStringProperty('nickname', 'Optional nickname', false);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.nickname).toBeDefined();
+            expect(npcProps.required).not.toContain('nickname');
+        });
+
+        it('should add string property with enum values', () => {
+            builder.addStringProperty('status', 'NPC status', true, ['active', 'inactive', 'dead']);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.status.enum).toEqual(['active', 'inactive', 'dead']);
+        });
+
+        it('should support method chaining', () => {
+            const result = builder
+                .addStringProperty('name', 'Name', true)
+                .addStringProperty('title', 'Title', false);
+
+            expect(result).toBe(builder);
+        });
+    });
+
+    describe('addArrayProperty', () => {
+        it('should add a required array property', () => {
+            builder.addArrayProperty('skills', 'List of skills', true);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.skills.type).toBe('array');
+            expect(npcProps.properties.skills.items?.type).toBe('string');
+            expect(npcProps.required).toContain('skills');
+        });
+
+        it('should add an optional array property', () => {
+            builder.addArrayProperty('inventory', 'Inventory items', false);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.inventory).toBeDefined();
+            expect(npcProps.required).not.toContain('inventory');
+        });
+
+        it('should add array property with enum values', () => {
+            builder.addArrayProperty('traits', 'Character traits', true, ['brave', 'cunning', 'wise']);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.traits.items?.enum).toEqual(['brave', 'cunning', 'wise']);
+        });
+    });
+
+    describe('addRelationship', () => {
+        it('should add a relationship as array property', () => {
+            builder.addRelationship('allies', 'allied_with', 'Allied NPCs');
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.properties.allies).toBeDefined();
+            expect(npcProps.properties.allies.type).toBe('array');
+        });
+
+        it('should store relationship configuration', () => {
+            builder.addRelationship('allies', 'allied_with', 'Allied NPCs', 'npc');
+            const schema = builder.build();
+
+            expect(schema.relationships.allies).toBeDefined();
+            expect(schema.relationships.allies.edgeType).toBe('allied_with');
+            expect(schema.relationships.allies.nodeType).toBe('npc');
+        });
+
+        it('should exclude relationship fields from metadata', () => {
+            builder.addRelationship('enemies', 'enemy_of', 'Enemy NPCs');
+            const schema = builder.build();
+
+            expect(schema.metadataConfig.excludeFields).toContain('enemies');
+        });
+    });
+
+    describe('allowAdditionalProperties', () => {
+        it('should enable additional properties', () => {
+            builder.allowAdditionalProperties(true);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.additionalProperties).toEqual({
+                type: 'string',
+                description: 'Additional property value'
+            });
+        });
+
+        it('should disable additional properties', () => {
+            builder.allowAdditionalProperties(false);
+            const schema = builder.build();
+
+            const npcProps = schema.inputSchema.properties.npc;
+            expect(npcProps.additionalProperties).toBe(false);
+        });
+    });
+
+    describe('createUpdateSchema', () => {
+        it('should create update schema with correct naming', () => {
+            builder.addStringProperty('name', 'Name', true);
+            const updateSchema = builder.createUpdateSchema();
+
+            expect(updateSchema.name).toBe('update_npc');
+            expect(updateSchema.description).toContain('Update');
+        });
+
+        it('should make all properties optional in update schema', () => {
+            builder.addStringProperty('name', 'Name', true);
+            builder.addStringProperty('title', 'Title', true);
+            const updateSchema = builder.createUpdateSchema();
+
+            const updateProps = updateSchema.inputSchema.properties.update_npc;
+            // In update schema, required fields should be empty or only contain non-property fields
+            expect(updateProps.required.includes('name')).toBe(false);
+        });
+
+        it('should exclude specified fields', () => {
+            builder.addStringProperty('name', 'Name', true);
+            builder.addStringProperty('secret', 'Secret', true);
+            const updateSchema = builder.createUpdateSchema(new Set(['secret']));
+
+            const updateProps = updateSchema.inputSchema.properties.update_npc;
+            expect(updateProps.properties.secret).toBeUndefined();
+            expect(updateProps.properties.name).toBeDefined();
+        });
+
+        it('should add metadata array property', () => {
+            builder.addStringProperty('name', 'Name', true);
+            const updateSchema = builder.createUpdateSchema();
+
+            const updateProps = updateSchema.inputSchema.properties.update_npc;
+            expect(updateProps.properties.metadata).toBeDefined();
+            expect(updateProps.properties.metadata.type).toBe('array');
+        });
+
+        it('should copy relationships to update schema', () => {
+            builder.addStringProperty('name', 'Name', true);
+            builder.addRelationship('allies', 'allied_with', 'Allies', 'npc');
+            const updateSchema = builder.createUpdateSchema();
+
+            expect(updateSchema.relationships.allies).toBeDefined();
+        });
+    });
+
+    describe('metadataConfig', () => {
+        it('should track required fields', () => {
+            builder.addStringProperty('name', 'Name', true);
+            builder.addStringProperty('type', 'Type', true);
+            const schema = builder.build();
+
+            expect(schema.metadataConfig.requiredFields).toContain('name');
+            expect(schema.metadataConfig.requiredFields).toContain('type');
+        });
+
+        it('should track optional fields', () => {
+            builder.addStringProperty('nickname', 'Nickname', false);
+            const schema = builder.build();
+
+            expect(schema.metadataConfig.optionalFields).toContain('nickname');
+        });
+
+        it('should track excluded fields from relationships', () => {
+            builder.addRelationship('friends', 'friend_of', 'Friends');
+            const schema = builder.build();
+
+            expect(schema.metadataConfig.excludeFields).toContain('friends');
+        });
+    });
+
+    describe('build', () => {
+        it('should return complete schema config', () => {
+            builder
+                .addStringProperty('name', 'Name', true)
+                .addArrayProperty('traits', 'Traits', false)
+                .addRelationship('allies', 'allied_with', 'Allies');
+
+            const schema = builder.build();
+
+            expect(schema).toHaveProperty('name');
+            expect(schema).toHaveProperty('description');
+            expect(schema).toHaveProperty('inputSchema');
+            expect(schema).toHaveProperty('relationships');
+            expect(schema).toHaveProperty('metadataConfig');
+        });
+
+        it('should be idempotent', () => {
+            builder.addStringProperty('name', 'Name', true);
+
+            const schema1 = builder.build();
+            const schema2 = builder.build();
+
+            expect(schema1).toEqual(schema2);
+        });
+    });
+});

--- a/tests/unit/shared/responseFormatter.test.ts
+++ b/tests/unit/shared/responseFormatter.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+    formatToolResponse,
+    formatToolError,
+    formatPartialSuccess
+} from '../../../src/shared/utils/responseFormatter.js';
+
+describe('responseFormatter', () => {
+    describe('formatToolResponse', () => {
+        it('should format a successful response with data', () => {
+            const result = formatToolResponse({
+                data: { nodes: [{ name: 'test', nodeType: 'npc' }] },
+                actionTaken: 'Added node'
+            });
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(1);
+            expect(result.content[0].type).toBe('text');
+            expect(result.structuredContent?.data).toEqual({ nodes: [{ name: 'test', nodeType: 'npc' }] });
+            expect(result.structuredContent?.actionTaken).toBe('Added node');
+            expect(result.structuredContent?.timestamp).toBeDefined();
+        });
+
+        it('should include message in content when provided', () => {
+            const result = formatToolResponse({
+                message: 'Operation completed',
+                data: { success: true }
+            });
+
+            expect(result.content).toHaveLength(2);
+            expect(result.content[0].text).toBe('Operation completed');
+        });
+
+        it('should include suggestions when provided', () => {
+            const result = formatToolResponse({
+                data: { result: 'ok' },
+                suggestions: ['Try this', 'Or that']
+            });
+
+            expect(result.structuredContent?.suggestions).toEqual(['Try this', 'Or that']);
+        });
+
+        it('should serialize data as JSON in text content for backwards compatibility', () => {
+            const data = { nodes: [{ name: 'test' }] };
+            const result = formatToolResponse({ data });
+
+            const jsonContent = result.content.find(c => c.text.includes('"nodes"'));
+            expect(jsonContent).toBeDefined();
+            expect(JSON.parse(jsonContent!.text)).toEqual(data);
+        });
+
+        it('should handle undefined data gracefully', () => {
+            const result = formatToolResponse({
+                actionTaken: 'Completed'
+            });
+
+            expect(result.isError).toBe(false);
+            expect(result.content).toHaveLength(0);
+            expect(result.structuredContent?.data).toBeUndefined();
+        });
+    });
+
+    describe('formatToolError', () => {
+        it('should format an error response', () => {
+            const result = formatToolError({
+                operation: 'add_nodes',
+                error: 'Node already exists'
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Error during add_nodes');
+            expect(result.content[0].text).toContain('Node already exists');
+        });
+
+        it('should include context in content when provided', () => {
+            const result = formatToolError({
+                operation: 'delete_nodes',
+                error: 'Node not found',
+                context: { nodeName: 'test' }
+            });
+
+            expect(result.content.length).toBeGreaterThan(1);
+            const contextContent = result.content.find(c => c.text.includes('Context'));
+            expect(contextContent).toBeDefined();
+        });
+
+        it('should include suggestions when provided', () => {
+            const result = formatToolError({
+                operation: 'update_nodes',
+                error: 'Invalid input',
+                suggestions: ['Check node name', 'Verify format']
+            });
+
+            expect(result.structuredContent?.suggestions).toEqual(['Check node name', 'Verify format']);
+        });
+
+        it('should include recovery steps when provided', () => {
+            const result = formatToolError({
+                operation: 'add_edges',
+                error: 'Source node missing',
+                recoverySteps: ['Create source node first', 'Retry operation']
+            });
+
+            expect(result.structuredContent?.recoverySteps).toEqual([
+                'Create source node first',
+                'Retry operation'
+            ]);
+        });
+
+        it('should include timestamp', () => {
+            const result = formatToolError({
+                operation: 'test',
+                error: 'Test error'
+            });
+
+            expect(result.structuredContent?.timestamp).toBeDefined();
+            expect(new Date(result.structuredContent!.timestamp!).getTime()).not.toBeNaN();
+        });
+    });
+
+    describe('formatPartialSuccess', () => {
+        it('should format a partial success response', () => {
+            const result = formatPartialSuccess({
+                operation: 'add_nodes',
+                attempted: ['node1', 'node2', 'node3'],
+                succeeded: ['node1', 'node2'],
+                failed: ['node3'],
+                details: { node3: 'Already exists' }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain('Partial success');
+            expect(result.content[0].text).toContain('2 succeeded');
+            expect(result.content[0].text).toContain('1 failed');
+        });
+
+        it('should include succeeded and failed items in structured content', () => {
+            const result = formatPartialSuccess({
+                operation: 'update_nodes',
+                attempted: ['a', 'b'],
+                succeeded: ['a'],
+                failed: ['b'],
+                details: { b: 'Not found' }
+            });
+
+            expect(result.structuredContent?.data?.succeededItems).toEqual(['a']);
+            expect(result.structuredContent?.data?.failedItems).toEqual([
+                { item: 'b', reason: 'Not found' }
+            ]);
+        });
+
+        it('should include default suggestions', () => {
+            const result = formatPartialSuccess({
+                operation: 'delete_nodes',
+                attempted: ['x'],
+                succeeded: [],
+                failed: ['x'],
+                details: { x: 'Error' }
+            });
+
+            expect(result.structuredContent?.suggestions).toBeDefined();
+            expect(result.structuredContent?.suggestions?.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/tests/unit/tools/mcpCompliance.test.ts
+++ b/tests/unit/tools/mcpCompliance.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { allStaticTools } from '../../../src/integration/tools/registry/staticTools.js';
+import type { Tool, ToolSchema, SchemaProperty } from '../../../src/shared/types/tools.js';
+
+/**
+ * MCP (Model Context Protocol) Compliance Tests
+ *
+ * These tests verify that tool definitions follow the MCP specification:
+ * https://modelcontextprotocol.io/specification/2025-11-25
+ *
+ * Key requirements tested:
+ * - Tool names must be strings
+ * - Tool descriptions should be provided
+ * - inputSchema must have type "object"
+ * - inputSchema.properties must be an object
+ * - inputSchema.required must be an array of strings (if present)
+ * - Property types must be valid JSON Schema types
+ */
+
+describe('MCP Compliance Tests', () => {
+    describe('Tool Definition Structure', () => {
+        allStaticTools.forEach((tool: Tool) => {
+            describe(`Tool: ${tool.name}`, () => {
+                it('should have a non-empty string name', () => {
+                    expect(typeof tool.name).toBe('string');
+                    expect(tool.name.length).toBeGreaterThan(0);
+                    // MCP recommends snake_case for tool names
+                    expect(tool.name).toMatch(/^[a-z][a-z0-9_]*$/);
+                });
+
+                it('should have a non-empty description', () => {
+                    expect(typeof tool.description).toBe('string');
+                    expect(tool.description.length).toBeGreaterThan(0);
+                });
+
+                it('should have inputSchema with type "object" (MCP requirement)', () => {
+                    expect(tool.inputSchema).toBeDefined();
+                    // MCP spec requires inputSchema.type to be literal "object"
+                    expect(tool.inputSchema.type).toBe('object');
+                });
+
+                it('should have properties object in inputSchema', () => {
+                    expect(tool.inputSchema.properties).toBeDefined();
+                    expect(typeof tool.inputSchema.properties).toBe('object');
+                });
+
+                it('should have valid required array if present', () => {
+                    if (tool.inputSchema.required !== undefined) {
+                        expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+                        tool.inputSchema.required.forEach((field: string) => {
+                            expect(typeof field).toBe('string');
+                            // Each required field should exist in properties
+                            expect(tool.inputSchema.properties).toHaveProperty(field);
+                        });
+                    }
+                });
+            });
+        });
+    });
+
+    describe('JSON Schema Compliance', () => {
+        const validJsonSchemaTypes = ['string', 'number', 'integer', 'boolean', 'array', 'object', 'null'];
+
+        const validatePropertySchema = (prop: SchemaProperty, path: string): void => {
+            // Type should be a valid JSON Schema type
+            expect(validJsonSchemaTypes).toContain(prop.type);
+
+            // Arrays should have items defined
+            if (prop.type === 'array' && prop.items) {
+                expect(validJsonSchemaTypes).toContain(prop.items.type);
+            }
+
+            // Objects should have properties defined
+            if (prop.type === 'object' && prop.properties) {
+                Object.entries(prop.properties).forEach(([key, value]) => {
+                    validatePropertySchema(value, `${path}.${key}`);
+                });
+            }
+
+            // Enum values should all be of the declared type
+            if (prop.enum) {
+                expect(Array.isArray(prop.enum)).toBe(true);
+                if (prop.type === 'string') {
+                    prop.enum.forEach(value => {
+                        expect(typeof value).toBe('string');
+                    });
+                }
+            }
+
+            // Min/max should be numbers
+            if (prop.minimum !== undefined) {
+                expect(typeof prop.minimum).toBe('number');
+            }
+            if (prop.maximum !== undefined) {
+                expect(typeof prop.maximum).toBe('number');
+            }
+        };
+
+        allStaticTools.forEach((tool: Tool) => {
+            it(`${tool.name} should have valid JSON Schema properties`, () => {
+                Object.entries(tool.inputSchema.properties).forEach(([key, value]) => {
+                    validatePropertySchema(value, key);
+                });
+            });
+        });
+    });
+
+    describe('MCP Response Format Compliance', () => {
+        it('should use correct content block types', () => {
+            // MCP specifies content blocks must have type: "text" | "image" | "resource"
+            const validContentTypes = ['text', 'image', 'resource', 'audio'];
+
+            // This is a static test - actual runtime validation happens elsewhere
+            expect(validContentTypes).toContain('text');
+        });
+
+        it('should support isError flag in responses', () => {
+            // MCP requires isError to be optional boolean
+            // Verified through type definitions
+            const mockResponse = { content: [], isError: true };
+            expect(typeof mockResponse.isError).toBe('boolean');
+        });
+    });
+
+    describe('Tool Naming Conventions', () => {
+        it('should have unique tool names', () => {
+            const names = allStaticTools.map(t => t.name);
+            const uniqueNames = new Set(names);
+            expect(names.length).toBe(uniqueNames.size);
+        });
+
+        it('should use snake_case for tool names', () => {
+            allStaticTools.forEach(tool => {
+                expect(tool.name).toMatch(/^[a-z][a-z0-9_]*$/);
+            });
+        });
+
+        it('should use descriptive action verbs in tool names', () => {
+            const actionVerbs = ['add', 'update', 'delete', 'read', 'search', 'open'];
+            allStaticTools.forEach(tool => {
+                const hasActionVerb = actionVerbs.some(verb => tool.name.startsWith(verb));
+                expect(hasActionVerb).toBe(true);
+            });
+        });
+    });
+
+    describe('Tool Description Quality', () => {
+        allStaticTools.forEach((tool: Tool) => {
+            it(`${tool.name} description should be informative`, () => {
+                // Description should not be too short
+                expect(tool.description.length).toBeGreaterThan(10);
+
+                // Description should not have leading/trailing whitespace
+                expect(tool.description).toBe(tool.description.trim());
+            });
+        });
+    });
+
+    describe('Input Validation Schema', () => {
+        describe('Graph mutation tools', () => {
+            const mutationTools = ['add_nodes', 'update_nodes', 'delete_nodes', 'add_edges', 'update_edges', 'delete_edges'];
+
+            mutationTools.forEach(toolName => {
+                const tool = allStaticTools.find(t => t.name === toolName);
+
+                if (tool) {
+                    it(`${toolName} should have required fields`, () => {
+                        expect(tool.inputSchema.required).toBeDefined();
+                        expect(tool.inputSchema.required!.length).toBeGreaterThan(0);
+                    });
+                }
+            });
+        });
+
+        describe('Search tools', () => {
+            it('read_graph should not require any input', () => {
+                const tool = allStaticTools.find(t => t.name === 'read_graph');
+                expect(tool).toBeDefined();
+                expect(Object.keys(tool!.inputSchema.properties).length).toBe(0);
+            });
+
+            it('search_nodes should require query parameter', () => {
+                const tool = allStaticTools.find(t => t.name === 'search_nodes');
+                expect(tool).toBeDefined();
+                expect(tool!.inputSchema.required).toContain('query');
+            });
+
+            it('open_nodes should require names parameter', () => {
+                const tool = allStaticTools.find(t => t.name === 'open_nodes');
+                expect(tool).toBeDefined();
+                expect(tool!.inputSchema.required).toContain('names');
+            });
+        });
+    });
+
+    describe('MCP Best Practices', () => {
+        it('should have read-only tools that do not require mutation parameters', () => {
+            const readOnlyTools = ['read_graph', 'search_nodes', 'open_nodes'];
+
+            readOnlyTools.forEach(toolName => {
+                const tool = allStaticTools.find(t => t.name === toolName);
+                expect(tool).toBeDefined();
+
+                // Read-only tools should not have mutation-like parameters
+                const props = Object.keys(tool!.inputSchema.properties);
+                props.forEach(prop => {
+                    expect(prop).not.toMatch(/delete|remove|update|modify/i);
+                });
+            });
+        });
+
+        it('should have descriptive property descriptions', () => {
+            allStaticTools.forEach(tool => {
+                Object.entries(tool.inputSchema.properties).forEach(([key, value]) => {
+                    if (value.description) {
+                        expect(value.description.length).toBeGreaterThan(5);
+                    }
+                });
+            });
+        });
+
+        it('should define array item schemas for array properties', () => {
+            allStaticTools.forEach(tool => {
+                Object.entries(tool.inputSchema.properties).forEach(([key, value]) => {
+                    if (value.type === 'array') {
+                        expect(value.items).toBeDefined();
+                    }
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/tools/staticTools.test.ts
+++ b/tests/unit/tools/staticTools.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import {
+    graphTools,
+    searchTools,
+    metadataTools,
+    allStaticTools
+} from '../../../src/integration/tools/registry/staticTools.js';
+import type { Tool } from '../../../src/shared/types/tools.js';
+
+describe('Static Tools - MCP Compliance', () => {
+    describe('Tool Definition Structure', () => {
+        it('should have all required tools defined', () => {
+            const expectedTools = [
+                'add_nodes', 'update_nodes', 'delete_nodes',
+                'add_edges', 'update_edges', 'delete_edges',
+                'read_graph', 'search_nodes', 'open_nodes',
+                'add_metadata', 'delete_metadata'
+            ];
+
+            const toolNames = allStaticTools.map(t => t.name);
+            expectedTools.forEach(name => {
+                expect(toolNames).toContain(name);
+            });
+        });
+
+        it('should have unique tool names', () => {
+            const names = allStaticTools.map(t => t.name);
+            const uniqueNames = new Set(names);
+            expect(names.length).toBe(uniqueNames.size);
+        });
+
+        allStaticTools.forEach((tool: Tool) => {
+            describe(`Tool: ${tool.name}`, () => {
+                it('should have a name', () => {
+                    expect(tool.name).toBeDefined();
+                    expect(typeof tool.name).toBe('string');
+                    expect(tool.name.length).toBeGreaterThan(0);
+                });
+
+                it('should have a description', () => {
+                    expect(tool.description).toBeDefined();
+                    expect(typeof tool.description).toBe('string');
+                    expect(tool.description.length).toBeGreaterThan(0);
+                });
+
+                it('should have inputSchema with type "object"', () => {
+                    expect(tool.inputSchema).toBeDefined();
+                    expect(tool.inputSchema.type).toBe('object');
+                });
+
+                it('should have properties defined in inputSchema', () => {
+                    expect(tool.inputSchema.properties).toBeDefined();
+                    expect(typeof tool.inputSchema.properties).toBe('object');
+                });
+            });
+        });
+    });
+
+    describe('Graph Tools', () => {
+        it('should have 6 graph tools', () => {
+            expect(graphTools).toHaveLength(6);
+        });
+
+        describe('add_nodes', () => {
+            const tool = graphTools.find(t => t.name === 'add_nodes')!;
+
+            it('should require nodes array', () => {
+                expect(tool.inputSchema.required).toContain('nodes');
+            });
+
+            it('should define nodes as array type', () => {
+                expect(tool.inputSchema.properties.nodes.type).toBe('array');
+            });
+
+            it('should require name, nodeType, metadata in node items', () => {
+                const items = tool.inputSchema.properties.nodes.items;
+                expect(items?.required).toContain('name');
+                expect(items?.required).toContain('nodeType');
+                expect(items?.required).toContain('metadata');
+            });
+        });
+
+        describe('add_edges', () => {
+            const tool = graphTools.find(t => t.name === 'add_edges')!;
+
+            it('should require edges array', () => {
+                expect(tool.inputSchema.required).toContain('edges');
+            });
+
+            it('should require from, to, edgeType in edge items', () => {
+                const items = tool.inputSchema.properties.edges.items;
+                expect(items?.required).toContain('from');
+                expect(items?.required).toContain('to');
+                expect(items?.required).toContain('edgeType');
+            });
+
+            it('should have optional weight with min/max constraints', () => {
+                const items = tool.inputSchema.properties.edges.items;
+                const weightProp = items?.properties?.weight;
+                expect(weightProp).toBeDefined();
+                expect(weightProp?.type).toBe('number');
+                expect(weightProp?.minimum).toBe(0);
+                expect(weightProp?.maximum).toBe(1);
+            });
+        });
+
+        describe('delete_nodes', () => {
+            const tool = graphTools.find(t => t.name === 'delete_nodes')!;
+
+            it('should require nodeNames array', () => {
+                expect(tool.inputSchema.required).toContain('nodeNames');
+            });
+
+            it('should define nodeNames as array of strings', () => {
+                expect(tool.inputSchema.properties.nodeNames.type).toBe('array');
+                expect(tool.inputSchema.properties.nodeNames.items?.type).toBe('string');
+            });
+        });
+    });
+
+    describe('Search Tools', () => {
+        it('should have 3 search tools', () => {
+            expect(searchTools).toHaveLength(3);
+        });
+
+        describe('read_graph', () => {
+            const tool = searchTools.find(t => t.name === 'read_graph')!;
+
+            it('should have empty properties (no required input)', () => {
+                expect(Object.keys(tool.inputSchema.properties)).toHaveLength(0);
+            });
+
+            it('should not have required fields', () => {
+                expect(tool.inputSchema.required).toBeUndefined();
+            });
+        });
+
+        describe('search_nodes', () => {
+            const tool = searchTools.find(t => t.name === 'search_nodes')!;
+
+            it('should require query parameter', () => {
+                expect(tool.inputSchema.required).toContain('query');
+            });
+
+            it('should define query as string', () => {
+                expect(tool.inputSchema.properties.query.type).toBe('string');
+            });
+        });
+
+        describe('open_nodes', () => {
+            const tool = searchTools.find(t => t.name === 'open_nodes')!;
+
+            it('should require names array', () => {
+                expect(tool.inputSchema.required).toContain('names');
+            });
+
+            it('should define names as array of strings', () => {
+                expect(tool.inputSchema.properties.names.type).toBe('array');
+                expect(tool.inputSchema.properties.names.items?.type).toBe('string');
+            });
+        });
+    });
+
+    describe('Metadata Tools', () => {
+        it('should have 2 metadata tools', () => {
+            expect(metadataTools).toHaveLength(2);
+        });
+
+        describe('add_metadata', () => {
+            const tool = metadataTools.find(t => t.name === 'add_metadata')!;
+
+            it('should require metadata array', () => {
+                expect(tool.inputSchema.required).toContain('metadata');
+            });
+
+            it('should require nodeName and contents in metadata items', () => {
+                const items = tool.inputSchema.properties.metadata.items;
+                expect(items?.required).toContain('nodeName');
+                expect(items?.required).toContain('contents');
+            });
+        });
+
+        describe('delete_metadata', () => {
+            const tool = metadataTools.find(t => t.name === 'delete_metadata')!;
+
+            it('should require deletions array', () => {
+                expect(tool.inputSchema.required).toContain('deletions');
+            });
+
+            it('should require nodeName and metadata in deletion items', () => {
+                const items = tool.inputSchema.properties.deletions.items;
+                expect(items?.required).toContain('nodeName');
+                expect(items?.required).toContain('metadata');
+            });
+        });
+    });
+
+    describe('MCP inputSchema Compliance', () => {
+        allStaticTools.forEach((tool: Tool) => {
+            it(`${tool.name} inputSchema.type should be literal "object"`, () => {
+                // MCP spec requires inputSchema.type to be exactly "object"
+                expect(tool.inputSchema.type).toBe('object');
+            });
+
+            it(`${tool.name} should have valid JSON Schema structure`, () => {
+                // All tools should have properties object
+                expect(tool.inputSchema.properties).toBeDefined();
+                expect(typeof tool.inputSchema.properties).toBe('object');
+
+                // If required is present, it should be an array
+                if (tool.inputSchema.required !== undefined) {
+                    expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+                }
+            });
+        });
+    });
+
+    describe('Tool Categories', () => {
+        it('allStaticTools should combine all tool categories', () => {
+            expect(allStaticTools.length).toBe(
+                graphTools.length + searchTools.length + metadataTools.length
+            );
+        });
+
+        it('should contain all graph tools', () => {
+            graphTools.forEach(tool => {
+                expect(allStaticTools).toContain(tool);
+            });
+        });
+
+        it('should contain all search tools', () => {
+            searchTools.forEach(tool => {
+                expect(allStaticTools).toContain(tool);
+            });
+        });
+
+        it('should contain all metadata tools', () => {
+            metadataTools.forEach(tool => {
+                expect(allStaticTools).toContain(tool);
+            });
+        });
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['tests/**/*.test.ts'],
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'json', 'html'],
+            include: ['src/**/*.ts'],
+            exclude: ['src/index.ts', 'src/**/*.d.ts']
+        },
+        testTimeout: 10000,
+    },
+    resolve: {
+        alias: {
+            '@core': path.resolve(__dirname, './src/core'),
+            '@infrastructure': path.resolve(__dirname, './src/infrastructure'),
+            '@application': path.resolve(__dirname, './src/application'),
+            '@integration': path.resolve(__dirname, './src/integration'),
+            '@shared': path.resolve(__dirname, './src/shared'),
+            '@data': path.resolve(__dirname, './src/data'),
+            '@config': path.resolve(__dirname, './src/config'),
+        },
+    },
+});


### PR DESCRIPTION
Add 306 tests covering MCP compliance and core functionality:

- Unit tests for response formatting (13 tests)
- Tool definition compliance tests (93 tests)
- MCP protocol compliance tests (94 tests)
- Graph tool handler tests (13 tests)
- Search tool handler tests (14 tests)
- Schema builder tests (25 tests)
- Graph validator tests (32 tests)
- Edge weight utils tests (22 tests)

Test infrastructure:
- Vitest configuration with path aliases
- Coverage reporting with v8 provider
- npm scripts: test, test:watch, test:coverage